### PR TITLE
Add matching

### DIFF
--- a/.github/workflows/ghc.yml
+++ b/.github/workflows/ghc.yml
@@ -1,0 +1,105 @@
+name: GHC (build, test, haddock)
+
+# Controls when the workflow will run
+'on':
+  push:
+    branches:
+      - master
+    tags: [v*]
+  pull_request:
+    branches:
+      - master
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: write # to submit Haddock documentation to GitHub Pages
+
+env:
+  syntax-dir: "free-foil-hou/src/Language/Lambda/Syntax"
+
+jobs:
+  tests:
+    name: Run tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+      fail-fast: false
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          ref: ${{ github.ref }}
+
+      - name: Restore Syntax files
+        id: restore-syntax-files
+        uses: actions/cache/restore@v4
+        with:
+          key: syntax-files-${{ runner.os }}-${{ hashFiles(format('{0}.cf', env.syntax-dir), 'stack.yaml.lock') }}
+          path: |
+            ${{ env.syntax-dir }}/Lex.hs
+            ${{ env.syntax-dir }}/Par.hs
+
+      - name: Check Syntax files exist
+        if: steps.restore-syntax-files.outputs.cache-hit == 'true'
+        shell: bash
+        id: check-syntax-files
+        run: |
+          source scripts/lib.sh
+          check_syntax_files_exist
+          printf "SYNTAX_FILES_EXIST=$SYNTAX_FILES_EXIST\n" >> $GITHUB_OUTPUT
+
+      - name: 🧰 Setup Stack
+        uses: freckle/stack-action@v5
+        with:
+          stack-build-arguments: --pedantic
+          stack-build-arguments-build: --dry-run
+          stack-build-arguments-test: --ghc-options -O2 ${{ steps.check-syntax-files.outputs.SYNTAX_FILES_EXIST == 'true' && ' ' || '--reconfigure --force-dirty --ghc-options -fforce-recomp' }}
+
+      - name: Save Syntax files
+        uses: actions/cache/save@v4
+        if: steps.restore-syntax-files.outputs.cache-hit != 'true'
+        with:
+          key: syntax-files-${{ runner.os }}-${{ hashFiles(format('{0}.cf', env.syntax-dir), 'stack.yaml.lock') }}
+          path: |
+            ${{ env.syntax-dir }}/Lex.hs
+            ${{ env.syntax-dir }}/Par.hs
+
+  docs:
+    needs: [tests]
+    name: "Build (all) and upload haddock (only master)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: 🧰 Setup Stack
+        uses: freckle/stack-action@v5
+        with:
+          test: false
+          stack-build-arguments: --fast --haddock
+          cache-prefix: docs-
+
+      - name: Download pipeline artifact
+        uses: actions/download-artifact@v4
+        with:
+          pattern: pipeline-files-${{ runner.os }}
+          merge-multiple: true
+
+      - name: Add haddock
+        run: |
+          mkdir -p dist/haddock
+          mv $(stack path --local-doc-root)/* dist/haddock
+
+      - name: 🚀 Publish Site
+        uses: JamesIves/github-pages-deploy-action@v4
+        if: ${{ github.ref_name == 'master' }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          folder: dist
+          single-commit: true

--- a/.github/workflows/ghc.yml
+++ b/.github/workflows/ghc.yml
@@ -55,7 +55,7 @@ jobs:
       - name: 🧰 Setup Stack
         uses: freckle/stack-action@v5
         with:
-          stack-build-arguments: --pedantic
+          stack-build-arguments: --pedantic --no-nix
           stack-build-arguments-build: --dry-run
           stack-build-arguments-test: --ghc-options -O2 ${{ steps.check-syntax-files.outputs.SYNTAX_FILES_EXIST == 'true' && ' ' || '--reconfigure --force-dirty --ghc-options -fforce-recomp' }}
 
@@ -82,7 +82,7 @@ jobs:
         uses: freckle/stack-action@v5
         with:
           test: false
-          stack-build-arguments: --fast --haddock
+          stack-build-arguments: --fast --haddock --no-nix
           cache-prefix: docs-
 
       - name: Download pipeline artifact

--- a/.github/workflows/ghc.yml
+++ b/.github/workflows/ghc.yml
@@ -4,11 +4,11 @@ name: GHC (build, test, haddock)
 'on':
   push:
     branches:
-      - master
+      - main
     tags: [v*]
   pull_request:
     branches:
-      - master
+      - main
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -70,7 +70,7 @@ jobs:
 
   docs:
     needs: [tests]
-    name: "Build (all) and upload haddock (only master)"
+    name: "Build (all) and upload haddock (only main)"
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout repository
@@ -98,7 +98,7 @@ jobs:
 
       - name: 🚀 Publish Site
         uses: JamesIves/github-pages-deploy-action@v4
-        if: ${{ github.ref_name == 'master' }}
+        if: ${{ github.ref_name == 'main' }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           folder: dist

--- a/.github/workflows/ghc.yml
+++ b/.github/workflows/ghc.yml
@@ -55,7 +55,7 @@ jobs:
       - name: 🧰 Setup Stack
         uses: freckle/stack-action@v5
         with:
-          stack-build-arguments: --pedantic --no-nix
+          stack-build-arguments: --pedantic
           stack-build-arguments-build: --dry-run
           stack-build-arguments-test: --ghc-options -O2 ${{ steps.check-syntax-files.outputs.SYNTAX_FILES_EXIST == 'true' && ' ' || '--reconfigure --force-dirty --ghc-options -fforce-recomp' }}
 

--- a/config.toml
+++ b/config.toml
@@ -10,8 +10,8 @@ constraints = [
 [[problems.solutions]]
 name = "most general"
 substitutions = [
-    "Y[x: magic] ↦ x x",
-    "X[f: magic -> t, x: magic] ↦ f (x x)",
+    "Y[a: magic] ↦ a a",
+    "X[b: magic -> t, c: magic] ↦ b (c c)",
 ]
 
 [[problems.solutions]]
@@ -20,4 +20,15 @@ substitutions = [
     "Y[x: magic] ↦ x x",
     "X[f: magic -> t, x: magic] ↦ f (x x)",
     "M[x: t, y: t -> u] ↦ y x"
+]
+
+[[problems]]
+constraints = [
+    "∀ x:t. M[λy:t. x, λa:t. λa:t. a] = λy:t. x"
+]
+
+[[problems.solutions]]
+name = "most general"
+substitutions = [
+    "M[a: t, b: t -> t] ↦ a",
 ]

--- a/config.toml
+++ b/config.toml
@@ -32,3 +32,33 @@ name = "most general"
 substitutions = [
     "M[a: t, b: t -> t] ↦ a",
 ]
+
+[[problems]]
+constraints = [
+    "∀ x:t, y:t. M[λz:t.N[x, y], x y] = λa:t.λb:t.x"
+]
+
+[[problems.solutions]]
+name = "some other solution"
+substitutions = [
+    "M[z1:t, z2:t] ↦ λa:t.z1",
+    "N[z1:t, z2:t] ↦ z1"
+]
+
+[[problems]]
+constraints = [
+    "∀ x:t, y:t. M[λz:t.N[x, y], x] = λa:t.λb:t.x"
+]
+
+[[problems.solutions]]
+name = "solution 1"
+substitutions = [
+    "M[z1:t, z2:t] ↦ λa:t.z1",
+    "N[z1:t, z2:t] ↦ z1"
+]
+
+[[problems.solutions]]
+name = "solution 2"
+substitutions = [
+    "M[z1:t, z2:t] ↦ λa:t.λb:t.z2",
+]

--- a/free-foil-hou.cabal
+++ b/free-foil-hou.cabal
@@ -87,10 +87,11 @@ executable free-foil-hou-exe
     , tomland
   default-language: Haskell2010
 
-test-suite free-foil-hou-test
+test-suite spec
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      Language.Lambda.ImplSpec
       Paths_free_foil_hou
   autogen-modules:
       Paths_free_foil_hou
@@ -103,12 +104,15 @@ test-suite free-foil-hou-test
   build-tool-depends:
       BNFC:bnfc >=2.9.4.1
   build-depends:
-      array >=0.5.3.0
+      QuickCheck
+    , array >=0.5.3.0
     , base >=4.7 && <5
     , bifunctors
     , containers
     , free-foil >=0.1.0
     , free-foil-hou
+    , hspec
+    , hspec-discover
     , kind-generics-th
     , text
     , tomland

--- a/package.yaml
+++ b/package.yaml
@@ -70,7 +70,7 @@ executables:
       - free-foil-hou
 
 tests:
-  free-foil-hou-test:
+  spec:
     main: Spec.hs
     source-dirs: test
     ghc-options:
@@ -79,3 +79,6 @@ tests:
       - -with-rtsopts=-N
     dependencies:
       - free-foil-hou
+      - hspec
+      - hspec-discover
+      - QuickCheck

--- a/src/Data/SOAS.hs
+++ b/src/Data/SOAS.hs
@@ -11,13 +11,18 @@
 module Data.SOAS where
 
 import qualified Control.Monad.Foil as Foil
+import qualified Control.Monad.Foil.Relative as Foil
 import Control.Monad.Free.Foil
+import Data.Bifoldable
 import Data.Bifunctor
 import Data.Bifunctor.Sum
 import Data.Bifunctor.TH
+import Data.Bitraversable (Bitraversable (bitraverse))
 import Data.ZipMatchK
+import Debug.Trace (trace)
 import qualified GHC.Generics as GHC
 import Generics.Kind.TH (deriveGenericK)
+import Unsafe.Coerce (unsafeCoerce)
 
 data MetaAppSig metavar scope term = MetaAppSig metavar [term]
   deriving (Functor, Foldable, Traversable, GHC.Generic)
@@ -37,6 +42,8 @@ instance (ZipMatchK a) => ZipMatchK (MetaAppSig a)
 
 type SOAS binder metavar sig n = AST binder (Sum sig (MetaAppSig metavar)) n
 
+type ScopedSOAS binder metavar sig n = ScopedAST binder (Sum sig (MetaAppSig metavar)) n
+
 pattern MetaApp
   :: metavar
   -> [SOAS binder metavar sig n]
@@ -50,13 +57,50 @@ data MetaAbs binder sig t where
     -> AST binder sig n
     -> MetaAbs binder sig t
 
-newtype MetaSubst binder sig metavar metavar' t = MetaSubst
-  { getMetaSubst :: (metavar, MetaAbs binder (Sum sig (MetaAppSig metavar')) t)
+newtype MetaSubst binder sig metavar ext t = MetaSubst
+  { getMetaSubst :: (metavar, MetaAbs binder (Sum sig ext) t)
   }
 
-newtype MetaSubsts binder sig metavar metavar' t = MetaSubsts
-  { getSubsts :: [MetaSubst binder sig metavar metavar' t]
+newtype MetaSubsts binder sig metavar ext t = MetaSubsts
+  { getMetaSubsts :: [MetaSubst binder sig metavar ext t]
   }
+
+-- M[x, y] M[y, x] = x y
+-- M[x, y] M[x, y] = x y
+
+combineMetaSubsts
+  :: (Eq metavar, Bitraversable sig, Bitraversable ext, ZipMatchK (Sum sig ext), Foil.UnifiablePattern binder, Foil.SinkableK binder)
+  => MetaSubsts binder sig metavar ext t
+  -> MetaSubsts binder sig metavar ext t
+  -> [MetaSubsts binder sig metavar ext t]
+combineMetaSubsts (MetaSubsts xs) (MetaSubsts ys)
+  | conflicts = []
+  | otherwise = [MetaSubsts (xs ++ ys)]
+ where
+  conflicts =
+    and
+      [ case Foil.unifyPatterns binders binders' of
+        Foil.SameNameBinders _ ->
+          case Foil.assertDistinct binders of
+            Foil.Distinct ->
+              let scope' = Foil.extendScopePattern binders Foil.emptyScope
+               in alphaEquiv scope' body body'
+        Foil.NotUnifiable -> False
+        -- FIXME: RenameLeftNameBinder _ _ -> undefined
+        _ -> undefined
+      | MetaSubst (m, MetaAbs binders _types body) <- xs
+      , MetaSubst (m', MetaAbs binders' _types' body') <- ys
+      , m == m'
+      ]
+
+combineMetaSubsts'
+  :: (Eq metavar, Bitraversable sig, Bitraversable ext, ZipMatchK (Sum sig ext), Foil.UnifiablePattern binder, Foil.SinkableK binder)
+  => [MetaSubsts binder sig metavar ext t]
+  -> [MetaSubsts binder sig metavar ext t]
+combineMetaSubsts' =
+  foldr
+    (\substs substsList -> concatMap (combineMetaSubsts substs) substsList)
+    []
 
 applyMetaSubsts
   :: ( Bifunctor sig
@@ -68,7 +112,7 @@ applyMetaSubsts
      )
   => (metavar -> metavar')
   -> Foil.Scope n
-  -> MetaSubsts binder sig metavar metavar' t
+  -> MetaSubsts binder sig metavar (MetaAppSig metavar') t
   -> SOAS binder metavar sig n
   -> SOAS binder metavar' sig n
 applyMetaSubsts rename scope substs = \case
@@ -76,7 +120,7 @@ applyMetaSubsts rename scope substs = \case
   -- FIXME: MetaApp metavar args ->
   Node (R2 (MetaAppSig metavar args)) ->
     let args' = map apply args
-     in case lookup metavar (getMetaSubst <$> getSubsts substs) of
+     in case lookup metavar (getMetaSubst <$> getMetaSubsts substs) of
           Just (MetaAbs names _types body) ->
             let nameMap = toNameMap Foil.emptyNameMap names args'
                 substs' = Foil.nameMapToSubstitution nameMap
@@ -105,7 +149,7 @@ applyMetaSubsts rename scope substs = \case
        )
     => (metavar -> metavar')
     -> Foil.Scope n
-    -> MetaSubsts binder sig metavar metavar' t
+    -> MetaSubsts binder sig metavar (MetaAppSig metavar') t
     -> ScopedAST binder (Sum sig (MetaAppSig metavar)) n
     -> ScopedAST binder (Sum sig (MetaAppSig metavar')) n
   goScoped rename' scope' substs' (ScopedAST binder body) =
@@ -114,3 +158,117 @@ applyMetaSubsts rename scope substs = \case
         ScopedAST binder (applyMetaSubsts rename' newScope substs' body)
    where
     newScope = Foil.extendScopePattern binder scope'
+
+-- | This function takes the following parameters:
+--
+--   * `Scope n` - The current scope.
+--   * `SOAS binder metavar sig n` - The left-hand side (where we want to apply
+--     substitutions).
+--   * `AST binder sig' n` - The right-hand side (unchangeable).
+--   * `[MetaSubsts sig' metavar]` - The substitutions that turn the LHS into
+--     the RHS.
+match
+  :: ( Bitraversable sig
+     , ZipMatchK sig
+     , Eq metavar
+     , Foil.Distinct n
+     , Foil.UnifiablePattern binder
+     , Foil.SinkableK binder
+     , Bitraversable ext
+     , ZipMatchK (Sum sig ext)
+     )
+  => Foil.Scope n
+  -> SOAS binder metavar sig n
+  -> AST binder (Sum sig ext) n
+  -> [MetaSubsts binder sig metavar ext t]
+match scope lhs rhs =
+  case (lhs, rhs) of
+    (Var x, Var y) | x == y -> return (MetaSubsts [])
+    (MetaApp metavar args, _) ->
+      trace "matching metavar" map addMetaSubst (matchMetavar scope args rhs)
+     where
+      addMetaSubst (metaAbs, MetaSubsts substs) =
+        MetaSubsts (MetaSubst (metavar, metaAbs) : substs)
+    (Node (L2 leftTerm), Node (L2 rightTerm)) ->
+      -- AppSig t1 t2 -- left term
+      -- AppSig a1 a2 -- right term
+      -- AppSig (t1, a1) (t2, a2) -- node
+      -- AppSig [s1, s2] [s3, s4] -- bimap _ (match ...) node
+      -- [AppSig s1 s3, AppSig s1 s4, AppSig s2 s3, AppSig s2 s4] -- bitraverse _ (match ...) node
+      -- [s1 + s3, s1 + s4, s2 + s3, s2 + s4] -- map (combineMetaSubsts' . biList) ...
+      -- [[s13], [], [], [s24]]
+      case zipMatch2 leftTerm rightTerm of
+        Just node ->
+          let tmp = bitraverse (uncurry (matchScoped scope)) (uncurry (match scope)) node
+           in trace "terms matched, combine substitutions" concatMap (combineMetaSubsts' . biList) tmp
+        Nothing -> trace "term structs doesn't match" []
+    (Node (L2 _term), Node (R2 _ext)) -> []
+    (_, Var _) -> []
+    (Var _, _) -> []
+    _ -> []
+
+matchScoped
+  :: ( Bitraversable sig
+     , ZipMatchK sig
+     , Foil.Distinct n
+     , Eq metavar
+     , Foil.UnifiablePattern binder
+     , Foil.SinkableK binder
+     , Bitraversable ext
+     , ZipMatchK (Sum sig ext)
+     )
+  => Foil.Scope n
+  -> ScopedSOAS binder metavar sig n
+  -> ScopedAST binder (Sum sig ext) n
+  -> [MetaSubsts binder sig metavar ext t]
+matchScoped scope (ScopedAST binder lhs) (ScopedAST binder' rhs) =
+  case trace "matching scoped terms" Foil.unifyPatterns binder binder' of
+    -- \x.t1 = \x.t2
+    Foil.SameNameBinders _ ->
+      case trace "same name binders" Foil.assertDistinct binder of
+        Foil.Distinct ->
+          let scope' = Foil.extendScopePattern binder scope
+           in match scope' lhs rhs
+    -- \x.t1 = \y.t2
+    Foil.RenameLeftNameBinder _ rename ->
+      case trace "rename left binder" Foil.assertDistinct binder' of
+        Foil.Distinct ->
+          let scope' = Foil.extendScopePattern binder' scope
+              lhs' = Foil.liftRM scope' (Foil.fromNameBinderRenaming rename) lhs
+           in match scope' lhs' rhs
+    Foil.RenameRightNameBinder _ rename ->
+      case trace "rename right binder" Foil.assertDistinct binder of
+        Foil.Distinct ->
+          let scope' = Foil.extendScopePattern binder scope
+              rhs' = Foil.liftRM scope' (Foil.fromNameBinderRenaming rename) rhs
+           in match scope' lhs rhs'
+    Foil.RenameBothBinders binders rename1 rename2 ->
+      case trace "rename both binders" Foil.assertDistinct binders of
+        Foil.Distinct ->
+          let scope' = Foil.extendScopePattern binders scope
+              lhs' = Foil.liftRM scope' (Foil.fromNameBinderRenaming rename1) lhs
+              rhs' = Foil.liftRM scope' (Foil.fromNameBinderRenaming rename2) rhs
+           in match scope' lhs' rhs'
+    Foil.NotUnifiable -> trace "not unifiable" []
+
+closed :: AST binder sig n -> Maybe (AST binder sig Foil.VoidS)
+closed term = Just (unsafeCoerce term)
+
+-- M[x, x] = x + x
+matchMetavar
+  :: Foil.Scope n
+  -> [SOAS binder metavar sig n]
+  -> AST binder (Sum sig ext) n
+  -> [(MetaAbs binder (Sum sig ext) t, MetaSubsts binder sig metavar ext t)]
+matchMetavar _scope args rhs =
+  case args of
+    [] ->
+      case closed rhs of
+        Just rhs' ->
+          trace "term is closed, substitute with rhs" [
+            ( MetaAbs Foil.NameBinderListEmpty Foil.emptyNameMap rhs'
+            , MetaSubsts []
+            )
+          ]
+        Nothing -> []
+    _ -> undefined

--- a/src/Data/SOAS.hs
+++ b/src/Data/SOAS.hs
@@ -81,7 +81,6 @@ newtype MetaSubsts binder sig metavar ext t = MetaSubsts
 applyMetaSubsts
   :: ( Bifunctor sig
      , Eq metavar
-     , Bifunctor (MetaAppSig metavar')
      , Foil.Distinct n
      , Foil.CoSinkable binder
      , Foil.SinkableK binder
@@ -118,7 +117,6 @@ applyMetaSubsts rename scope substs = \case
   goScoped
     :: ( Bifunctor sig
        , Eq metavar
-       , Bifunctor (MetaAppSig metavar')
        , Foil.Distinct n
        , Foil.CoSinkable binder
        , Foil.SinkableK binder
@@ -177,7 +175,7 @@ combineMetaSubsts = foldr go []
 --
 -- If matching is successful, it produces metavariable substitutions that when applied to LHS make it syntactically equal to RHS.
 -- For example, matching
---   M[f x, g]) = g (f x)
+--   M[f x, g] = g (f x)
 -- produces substitution
 --   M[z₁, z₂] ↦ z₂ z₁
 --

--- a/src/Language/Lambda/Impl.hs
+++ b/src/Language/Lambda/Impl.hs
@@ -241,10 +241,6 @@ withMetaSubstVars (Raw.ABinder ident type_ : idents) scope env binderList binder
         binderList' = push binder binderList
         binderTypes' = Foil.addNameBinder binder type_ binderTypes
      in withMetaSubstVars idents scope' env' binderList' binderTypes' cont
- where
-  push :: Foil.NameBinder i l -> NameBinderList n i -> NameBinderList n l
-  push x NameBinderListEmpty = NameBinderListCons x NameBinderListEmpty
-  push x (NameBinderListCons y ys) = NameBinderListCons y (push x ys)
 
 type MetaSubst' =
   MetaSubst
@@ -608,23 +604,37 @@ parseConfigAndValidate = do
 main :: IO ()
 -- main = parseConfigAndValidate
 main = do
-  let lhs = "λy:t. M[]" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
+  let lhs = "M[λy:t. λx:t. x, λa:t. λa:t. a]" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
   let rhs = "λy:t. λx:t. x" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
   let res = match Foil.emptyScope lhs rhs :: [MetaSubsts']
   print res
 
+-- >>> lhs = "M[λx:t.x, λx:t.x]" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
+-- >>> rhs = "λx:t.x" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
+-- >>> match Foil.emptyScope lhs rhs :: [MetaSubsts']
+-- Prelude.undefined
+
+-- >>> lhs = "M[λy:t. y, λa:t. λa:t. a]" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
+-- >>> rhs = "λy:t. y" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
+-- >>> match Foil.emptyScope lhs rhs :: [MetaSubsts']
+-- [[M [x0 : T, x1 : T] ↦ x0]]
+
 -- >>> lhs = "M[]" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
 -- >>> rhs = "λx:t.x" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
 -- >>> match Foil.emptyScope lhs rhs :: [MetaSubsts']
--- [[M [] ↦ λ x0 : t . x0]]
+-- [[M [x0 : T] ↦ x0]]
 
 -- >>> lhs = "λx : t. x" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
 -- >>> rhs = "λy : t. y" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
 -- >>> match Foil.emptyScope lhs rhs :: [MetaSubsts']
 -- [[]]
 
+-- >>> lhs = "λx : t. λx : t. x" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
+-- >>> rhs = "λy : t. y" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
+-- >>> match Foil.emptyScope lhs rhs :: [MetaSubsts']
+-- []
+
 -- >>> lhs = "λy:t. M[]" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
 -- >>> rhs = "λy:t. λx:t. x" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
 -- >>> match Foil.emptyScope lhs rhs :: [MetaSubsts']
 -- [[M [] ↦ λ x1 : t . x1]]
-

--- a/src/Language/Lambda/Impl.hs
+++ b/src/Language/Lambda/Impl.hs
@@ -620,11 +620,11 @@ main = do
 
 -- >>> lhs = "λx : t. x" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
 -- >>> rhs = "λy : t. y" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
--- >>> match Foil.emptyScope lhs lhs :: [MetaSubsts']
--- []
+-- >>> match Foil.emptyScope lhs rhs :: [MetaSubsts']
+-- [[]]
 
 -- >>> lhs = "λy:t. M[]" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
 -- >>> rhs = "λy:t. λx:t. x" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
 -- >>> match Foil.emptyScope lhs rhs :: [MetaSubsts']
--- []
+-- [[M [] ↦ λ x1 : t . x1]]
 

--- a/src/Language/Lambda/Impl.hs
+++ b/src/Language/Lambda/Impl.hs
@@ -124,16 +124,30 @@ instance ZipMatchK Raw.Type where zipMatchWithK = zipMatchViaEq
 
 -- ** Pattern synonyms
 
-pattern App' :: AST binder (Sum TermSig q) n -> AST binder (Sum TermSig q) n -> AST binder (Sum TermSig q) n
+pattern App'
+  :: AST binder (Sum TermSig q) n
+  -> AST binder (Sum TermSig q) n
+  -> AST binder (Sum TermSig q) n
 pattern App' f x = Node (L2 (AppSig f x))
 
-pattern Lam' :: Raw.Type -> binder n l -> AST binder (Sum TermSig q) l -> AST binder (Sum TermSig q) n
+pattern Lam'
+  :: Raw.Type
+  -> binder n l
+  -> AST binder (Sum TermSig q) l
+  -> AST binder (Sum TermSig q) n
 pattern Lam' typ binder body = Node (L2 (LamSig typ (ScopedAST binder body)))
 
-pattern Let' :: AST binder (Sum TermSig q) n -> binder n l -> AST binder (Sum TermSig q) l -> AST binder (Sum TermSig q) n
+pattern Let'
+  :: AST binder (Sum TermSig q) n
+  -> binder n l
+  -> AST binder (Sum TermSig q) l
+  -> AST binder (Sum TermSig q) n
 pattern Let' term binder body = Node (L2 (LetSig term (ScopedAST binder body)))
 
-pattern MetaVar' :: Raw.MetaVarIdent -> [AST binder (Sum TermSig q) n] -> AST binder (Sum TermSig q) n
+pattern MetaVar'
+  :: Raw.MetaVarIdent
+  -> [AST binder (Sum TermSig q) n]
+  -> AST binder (Sum TermSig q) n
 pattern MetaVar' metavar args = Node (L2 (MetaVarSig metavar args))
 
 -- FV( (λ x. x) y )  =  { y }
@@ -602,27 +616,31 @@ parseConfigAndValidate = do
     mapM_ printInvalidSolutionsWithConstraint invalidSolutionsWithConstraints
 
 main :: IO ()
--- main = parseConfigAndValidate
-main = do
-  let lhs = "M[λy:t. λx:t. x, λa:t. λa:t. a]" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
-  let rhs = "λy:t. λx:t. x" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
-  let res = match Foil.emptyScope lhs rhs :: [MetaSubsts']
-  print res
+main = parseConfigAndValidate
+-- main = do
+--   let lhs = "M[λy:t. λx:t. x, λa:t. λa:t. a]" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
+--   let rhs = "λy:t. λx:t. x" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
+--   let res = match Foil.emptyScope lhs rhs :: [MetaSubsts']
+--   print res
+
+-- ∀ x, y. M[λz.N[x, y], x y] = λa.λb.x
+-- M [z1, z2] ↦ λa.z1
+-- N [z1, z2] ↦ z1
 
 -- >>> lhs = "M[λx:t.x, λx:t.x]" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
 -- >>> rhs = "λx:t.x" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
 -- >>> match Foil.emptyScope lhs rhs :: [MetaSubsts']
--- Prelude.undefined
+-- [[M [x0 : T, x1 : T] ↦ x0],[M [x0 : T, x1 : T] ↦ x1],[M [x0 : T, x1 : T] ↦ λ x2 : t . x2]]
 
 -- >>> lhs = "M[λy:t. y, λa:t. λa:t. a]" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
 -- >>> rhs = "λy:t. y" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
 -- >>> match Foil.emptyScope lhs rhs :: [MetaSubsts']
--- [[M [x0 : T, x1 : T] ↦ x0]]
+-- [[M [x0 : T, x1 : T] ↦ x0],[M [x0 : T, x1 : T] ↦ λ x2 : t . x2]]
 
 -- >>> lhs = "M[]" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
 -- >>> rhs = "λx:t.x" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
 -- >>> match Foil.emptyScope lhs rhs :: [MetaSubsts']
--- [[M [x0 : T] ↦ x0]]
+-- [[M [] ↦ λ x0 : t . x0]]
 
 -- >>> lhs = "λx : t. x" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
 -- >>> rhs = "λy : t. y" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
@@ -634,7 +652,7 @@ main = do
 -- >>> match Foil.emptyScope lhs rhs :: [MetaSubsts']
 -- []
 
--- >>> lhs = "λy:t. M[]" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
+-- >>> lhs = "λy:t. M[λx:t. x]" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
 -- >>> rhs = "λy:t. λx:t. x" :: MetaTerm Raw.MetaVarIdent Foil.VoidS
 -- >>> match Foil.emptyScope lhs rhs :: [MetaSubsts']
--- [[M [] ↦ λ x1 : t . x1]]
+-- [[M [x0 : T] ↦ x0],[M [x0 : T] ↦ λ x1 : t . x1]]

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,25 +1,10 @@
 resolver: nightly-2024-10-21
 
 # User packages to be built.
-# Various formats can be used as shown in the example below.
-#
-# packages:
-# - some-directory
-# - https://example.com/foo/bar/baz-0.0.2.tar.gz
-#   subdirs:
-#   - auto-update
-#   - wai
 packages:
 - .
+
 # Dependency packages to be pulled from upstream that are not in the resolver.
-# These entries can reference officially published versions as well as
-# forks / in-progress versions pinned to a git hash. For example:
-#
-# extra-deps:
-# - acme-missiles-0.3
-# - git: https://github.com/commercialhaskell/stack.git
-#   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a
-#
 extra-deps:
   - git: https://github.com/fizruk/free-foil.git
     commit: b57f37331ff4817b1a29337230711e2a4914fe64
@@ -31,31 +16,3 @@ extra-deps:
 allow-newer: true
 allow-newer-deps:
   - kind-generics-th
-
-# Override default flag values for local packages and extra-deps
-# flags: {}
-
-# Extra package databases containing global packages
-# extra-package-dbs: []
-
-# Control whether we use the GHC we find on the path
-# system-ghc: true
-#
-# Require a specific version of Stack, using version ranges
-# require-stack-version: -any # Default
-# require-stack-version: ">=2.15"
-#
-# Override the architecture used by Stack, especially useful on Windows
-# arch: i386
-# arch: x86_64
-#
-# Extra directories used by Stack for building
-# extra-include-dirs: [/path/to/dir]
-# extra-lib-dirs: [/path/to/dir]
-#
-# Allow a newer minor version of GHC than the snapshot specifies
-# compiler-check: newer-minor
-
-# If you are not using Nix, run `stack build --no-nix`
-nix:
-  enable: true  # false by default, except on NixOS

--- a/test/Language/Lambda/ImplSpec.hs
+++ b/test/Language/Lambda/ImplSpec.hs
@@ -1,0 +1,31 @@
+{-# OPTIONS_GHC -Wno-type-defaults #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+module Language.Lambda.ImplSpec where
+
+import Data.Either (isRight)
+import Control.Monad (forM_)
+import Test.Hspec
+import qualified Data.Text as Text
+import qualified Toml
+import System.Exit (exitFailure)
+
+import Language.Lambda.Impl as Impl
+
+spec :: Spec
+spec = do
+  Impl.Config{..} <- runIO $ do
+    configResult <- Toml.decodeFileEither configCodec "config.toml"
+    case configResult of
+      Left err -> do
+        print err
+        exitFailure
+      Right config -> return config
+  
+  let title = Text.unpack (configLanguage <> " (fragment: " <> configFragment <> ")")
+  describe title $
+    forM_ (zip [1..] configProblems) $ \(i, Impl.Problem{..}) -> do
+      describe ("problem #" <> show i) $ do
+        forM_ problemSolutions $ \solution@Impl.Solution{..} -> do
+          it (Text.unpack solutionName) $ do
+            Impl.validateSolution problemConstraints solution `shouldSatisfy` isRight

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,2 +1,1 @@
-main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}


### PR DESCRIPTION
This PR primarily adds second-order syntactic matching, i.e. the ability to solve systems of constraints where
1. only the left hand side may have metavariables (that are solved for)
2. terms equality is considered purely syntactically (modulo substitution of metavariables), i.e. no $\beta\eta$-reductions or anything similar

This PR implements
- [x] untyped second-order matching (types are ignored and dummy types are used)
- [ ] typed second-order matching

Additionally, this PR also contributes
- A `spec` test suite that runs all examples from a sample `config.toml`, where unification problems and their various solutions are presented in a human-readable form
- A GitHub Action for building and testing this project and its Haddock documentation with Stack (as well as uploading the documentation on GitHub Pages when on `main` branch)